### PR TITLE
Fixed .editorconfig formatting issues and improved compatibility

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,8 +15,11 @@ indent_size = 4
 [*.rs]
 max_line_length = 100
 
-[*.{yml,yaml}]
+[*.yml]
 indent_size = 2
+
+[*.yaml]
+indent_size = 2  
 
 [*.md]
 # double whitespace at end of line
@@ -25,5 +28,3 @@ trim_trailing_whitespace = false
 
 [Makefile]
 indent_style = tab
-
-[]


### PR DESCRIPTION
### Changes:
1. **Removed Empty Section**:
   - Removed the invalid `[]` section at the end of the `.editorconfig` file.

2. **Improved YAML Compatibility**:
   - Split the `[*.{yml,yaml}]` section into separate sections `[*.yml]` and `[*.yaml]` to ensure compatibility with older editors that do not support wildcard patterns.
   - Updated the `indent_size` setting for both YAML file types to maintain consistency.

### Why These Changes?
- The empty `[]` section was invalid and could cause issues with some `.editorconfig` parsers.
- Some older editors do not support wildcard patterns like `[*.{yml,yaml}]`, so splitting them into separate sections ensures broader compatibility.
- These changes make the `.editorconfig` file cleaner, more maintainable, and compatible with a wider range of tools.