### PR TITLE
fix typo Update build_block.rs

### DIFF
--- a/bin/reth/src/commands/debug_cmd/build_block.rs
+++ b/bin/reth/src/commands/debug_cmd/build_block.rs
@@ -78,7 +78,7 @@ pub struct Command {
 }
 
 impl Command {
-    /// Fetches the best block block from the database.
+    /// Fetches the best block from the database.
     ///
     /// If the database is empty, returns the genesis block.
     fn lookup_best_block(
@@ -113,7 +113,7 @@ impl Command {
         }
     }
 
-    /// Execute `debug in-memory-merkle` command
+    /// Execute `debug build-block` command
     pub async fn execute(self, ctx: CliContext) -> eyre::Result<()> {
         let Environment { provider_factory, .. } = self.env.init(AccessRights::RW)?;
 


### PR DESCRIPTION
1)The previous comment appears to be a leftover from a copy-paste of another debug command (likely in-memory-merkle). This command is unrelated to build-block, so the correction improves clarity and documentation accuracy.

This is a non-functional change (docs only) but helps avoid confusion for contributors and maintainers navigating the codebase.

2)/// Fetches the best block block from the database --->>/// Fetches the best block from the database.