### PR TITLE
fix typo Update execution.rs

### DIFF
--- a/bin/reth/src/commands/debug_cmd/execution.rs
+++ b/bin/reth/src/commands/debug_cmd/execution.rs
@@ -16,7 +16,7 @@ use reth_downloaders::{
     bodies::bodies::BodiesDownloaderBuilder,
     headers::reverse_headers::ReverseHeadersDownloaderBuilder,
 };
-use reth_exex::ExExManagerHandle;
+use reth_exec::ExExManagerHandle;
 use reth_network::{BlockDownloaderProvider, NetworkEventListenerProvider, NetworkHandle};
 use reth_network_api::NetworkInfo;
 use reth_network_p2p::{headers::client::HeadersClient, BlockClient};


### PR DESCRIPTION
correct typo in crate import (reth_exex ---> reth_exec)

This ensures the compiler picks up the real `reth_exec` crate (as defined in `Cargo.toml`) and resolves the import correctly.